### PR TITLE
Cleanup and Update Generic API

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,17 @@ type Person struct {
 func main() {
 	ctx := context.Background()
 
-	client, err := instructor.FromOpenAI[Person](
+	client, err := instructor.FromOpenAI(
 		openai.NewClient(os.Getenv("OPENAI_API_KEY")),
 		instructor.WithMode(instructor.ModeJSON),
-		instructor.WithMaxRetries(5),
+		instructor.WithMaxRetries(3),
 	)
 	if err != nil {
 		panic(err)
 	}
 
-	person, err := client.CreateChatCompletion(
+	var person Person
+	err = client.CreateChatCompletion(
 		ctx,
 		instructor.Request{
 			Model: openai.GPT4Turbo20240409,
@@ -58,6 +59,7 @@ func main() {
 				},
 			},
 		},
+		&person,
 	)
 	if err != nil {
 		panic(err)

--- a/examples/function_calling/main.go
+++ b/examples/function_calling/main.go
@@ -29,9 +29,13 @@ func (s *Search) execute() {
 
 type Searches = []Search
 
+// type Searches struct {
+// 	Items []Search `json:"searches" jsonschema:"title=Searches,description=A list of search results"`
+// }
+
 func segment(ctx context.Context, data string) *Searches {
 
-	client, err := instructor.FromOpenAI[Searches](
+	client, err := instructor.FromOpenAI(
 		openai.NewClient(os.Getenv("OPENAI_API_KEY")),
 		instructor.WithMode(instructor.ModeToolCall),
 		instructor.WithMaxRetries(3),
@@ -40,10 +44,11 @@ func segment(ctx context.Context, data string) *Searches {
 		panic(err)
 	}
 
-	searches, err := client.CreateChatCompletion(
+	var searches Searches
+	err = client.CreateChatCompletion(
 		ctx,
 		instructor.Request{
-			Model: openai.GPT4Turbo20240409,
+			Model: openai.GPT4o,
 			Messages: []instructor.Message{
 				{
 					Role:    instructor.RoleUser,
@@ -51,12 +56,13 @@ func segment(ctx context.Context, data string) *Searches {
 				},
 			},
 		},
+		&searches,
 	)
 	if err != nil {
 		panic(err)
 	}
 
-	return searches
+	return &searches
 }
 
 func main() {

--- a/examples/images/anthropic/main.go
+++ b/examples/images/anthropic/main.go
@@ -32,7 +32,7 @@ func (bc *MovieCatalog) PrintCatalog() {
 func main() {
 	ctx := context.Background()
 
-	client, err := instructor.FromAnthropic[MovieCatalog](
+	client, err := instructor.FromAnthropic(
 		anthropic.NewClient(os.Getenv("ANTHROPIC_API_KEY")),
 		instructor.WithMode(instructor.ModeJSONSchema),
 		instructor.WithMaxRetries(3),
@@ -43,7 +43,8 @@ func main() {
 
 	url := "https://utfs.io/f/bd0dbae6-27e3-4604-b640-fd2ffea891b8-fxyywt.jpeg"
 
-	movieCatalog, err := client.CreateChatCompletion(
+	var movieCatalog MovieCatalog
+	err = client.CreateChatCompletion(
 		ctx,
 		instructor.Request{
 			Model: "claude-3-haiku-20240307",
@@ -65,6 +66,7 @@ func main() {
 				},
 			},
 		},
+		&movieCatalog,
 	)
 	if err != nil {
 		panic(err)

--- a/examples/images/openai/main.go
+++ b/examples/images/openai/main.go
@@ -30,7 +30,7 @@ func (bc *BookCatalog) PrintCatalog() {
 func main() {
 	ctx := context.Background()
 
-	client, err := instructor.FromOpenAI[BookCatalog](
+	client, err := instructor.FromOpenAI(
 		openai.NewClient(os.Getenv("OPENAI_API_KEY")),
 		instructor.WithMode(instructor.ModeJSON),
 		instructor.WithMaxRetries(3),
@@ -41,7 +41,8 @@ func main() {
 
 	url := "https://utfs.io/f/fe55d6bd-e920-4a6f-8e93-a4c9dd851b90-eivhb2.png"
 
-	bookCatalog, err := client.CreateChatCompletion(
+	var bookCatalog BookCatalog
+	err = client.CreateChatCompletion(
 		ctx,
 		instructor.Request{
 			Model: openai.GPT4o,
@@ -63,6 +64,7 @@ func main() {
 				},
 			},
 		},
+		&bookCatalog,
 	)
 
 	if err != nil {

--- a/examples/user/main.go
+++ b/examples/user/main.go
@@ -17,7 +17,7 @@ type Person struct {
 func main() {
 	ctx := context.Background()
 
-	client, err := instructor.FromOpenAI[Person](
+	client, err := instructor.FromOpenAI(
 		openai.NewClient(os.Getenv("OPENAI_API_KEY")),
 		instructor.WithMode(instructor.ModeJSON),
 		instructor.WithMaxRetries(3),
@@ -26,7 +26,8 @@ func main() {
 		panic(err)
 	}
 
-	person, err := client.CreateChatCompletion(
+	var person Person
+	err = client.CreateChatCompletion(
 		ctx,
 		instructor.Request{
 			Model: openai.GPT4Turbo20240409,
@@ -37,6 +38,7 @@ func main() {
 				},
 			},
 		},
+		&person,
 	)
 	if err != nil {
 		panic(err)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.8
 
 require (
 	github.com/invopop/jsonschema v0.12.0
-	github.com/liushuangls/go-anthropic/v2 v2.0.3
+	github.com/liushuangls/go-anthropic/v2 v2.1.0
 	github.com/sashabaranov/go-openai v1.24.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/invopop/jsonschema v0.12.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uO
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/liushuangls/go-anthropic/v2 v2.0.3 h1:vNA74jYpBxqXxpj3b/+iLtvfQ6fwCY56pseIAPCItQs=
 github.com/liushuangls/go-anthropic/v2 v2.0.3/go.mod h1:8BKv/fkeTaL5R9R9bGkaknYBueyw2WxY20o7bImbOek=
+github.com/liushuangls/go-anthropic/v2 v2.1.0 h1:5ntOeehozlMin0+hgnhxbTru+tmBH84ADaSPelG5fPg=
+github.com/liushuangls/go-anthropic/v2 v2.1.0/go.mod h1:8BKv/fkeTaL5R9R9bGkaknYBueyw2WxY20o7bImbOek=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/pkg/instructor/client.go
+++ b/pkg/instructor/client.go
@@ -4,10 +4,12 @@ import (
 	"context"
 )
 
-type Client[T any] interface {
+type Client interface {
 	CreateChatCompletion(
 		ctx context.Context,
 		request Request,
+		mode Mode,
+		schema *Schema,
 	) (string, error)
 
 	// TODO: implement streaming

--- a/pkg/instructor/instructor.go
+++ b/pkg/instructor/instructor.go
@@ -11,81 +11,70 @@ import (
 	openai "github.com/sashabaranov/go-openai"
 )
 
-type Instructor[T any] struct {
-	Client     Client[T]
+type Instructor struct {
+	Client     Client
 	Provider   Provider
 	Mode       Mode
 	MaxRetries int
-
-	Schema *Schema[T]
-	Type   reflect.Type
 }
 
-func FromOpenAI[T any](client *openai.Client, opts ...Options) (*Instructor[T], error) {
+func FromOpenAI(client *openai.Client, opts ...Options) (*Instructor, error) {
 
 	options := mergeOptions(opts...)
 
-	schema, err := NewSchema[T]()
+	cli, err := NewOpenAIClient(client)
 	if err != nil {
 		return nil, err
 	}
 
-	cli, err := NewOpenAIClient(client, schema, *options.Mode)
-	if err != nil {
-		return nil, err
-	}
-
-	t := reflect.TypeOf(new(T))
-
-	i := &Instructor[T]{
+	i := &Instructor{
 		Client:     cli,
 		Provider:   OpenAI,
 		Mode:       *options.Mode,
 		MaxRetries: *options.MaxRetries,
-		Schema:     schema,
-		Type:       t,
 	}
 	return i, nil
 }
 
-func FromAnthropic[T any](client *anthropic.Client, opts ...Options) (*Instructor[T], error) {
+func FromAnthropic(client *anthropic.Client, opts ...Options) (*Instructor, error) {
 
 	options := mergeOptions(opts...)
 
-	schema, err := NewSchema[T]()
+	cli, err := NewAnthropicClient(client)
 	if err != nil {
 		return nil, err
 	}
 
-	cli, err := NewAnthropicClient(client, schema, *options.Mode)
-	if err != nil {
-		return nil, err
-	}
-
-	t := reflect.TypeOf(new(T))
-
-	i := &Instructor[T]{
+	i := &Instructor{
 		Client:     cli,
 		Provider:   OpenAI,
 		Mode:       *options.Mode,
 		MaxRetries: *options.MaxRetries,
-		Schema:     schema,
-		Type:       t,
 	}
 	return i, nil
 }
 
-func (i *Instructor[T]) CreateChatCompletion(ctx context.Context, request Request) (*T, error) {
+func (i *Instructor) CreateChatCompletion(ctx context.Context, request Request, response any) error {
+
+	t := reflect.TypeOf(response)
+
+	schema, err := NewSchema(t)
+	if err != nil {
+		return err
+	}
 
 	for attempt := 0; attempt < i.MaxRetries; attempt++ {
 
-		text, err := i.Client.CreateChatCompletion(ctx, request)
+		text, err := i.Client.CreateChatCompletion(ctx, request, i.Mode, schema)
 		if err != nil {
 			// no retry on non-marshalling/validation errors
-			return nil, err
+			// return err
+			continue
 		}
 
-		t, err := i.processResponse(text)
+		text = extractJSON(text)
+
+		err = processResponse(text, &response)
 		if err != nil {
 			// TODO:
 			// add more sophisticated retry logic (send back json and parse error for model to fix).
@@ -95,47 +84,64 @@ func (i *Instructor[T]) CreateChatCompletion(ctx context.Context, request Reques
 			continue
 		}
 
-		return t, nil
+		return nil
 	}
 
-	return nil, errors.New("hit max retry attempts")
+	return errors.New("hit max retry attempts")
 }
 
-func (i *Instructor[T]) processResponse(response string) (*T, error) {
+func processResponse(responseStr string, response *any) error {
 
-	response = trimJSON(response)
-
-	t := new(T)
-
-	err := json.Unmarshal([]byte(response), t)
+	err := json.Unmarshal([]byte(responseStr), response)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// TODO: if direct unmarshal fails: check common erors like wrapping struct with key name of struct, instead of just the value
 
-	return t, nil
+	return nil
 }
 
 // Removes any prefixes before the JSON (like "Sure, here you go:")
 func trimPrefix(jsonStr string) string {
-	start := strings.IndexByte(jsonStr, '{')
-	if start == -1 {
-		return jsonStr // No opening brace found, return the original string
+	startObject := strings.IndexByte(jsonStr, '{')
+	startArray := strings.IndexByte(jsonStr, '[')
+
+	var start int
+	if startObject == -1 && startArray == -1 {
+		return jsonStr // No opening brace or bracket found, return the original string
+	} else if startObject == -1 {
+		start = startArray
+	} else if startArray == -1 {
+		start = startObject
+	} else {
+		start = min(startObject, startArray)
 	}
+
 	return jsonStr[start:]
 }
 
 // Removes any postfixes after the JSON
 func trimPostfix(jsonStr string) string {
-	end := strings.LastIndexByte(jsonStr, '}')
-	if end == -1 {
-		return jsonStr
+	endObject := strings.LastIndexByte(jsonStr, '}')
+	endArray := strings.LastIndexByte(jsonStr, ']')
+
+	var end int
+	if endObject == -1 && endArray == -1 {
+		return jsonStr // No closing brace or bracket found, return the original string
+	} else if endObject == -1 {
+		end = endArray
+	} else if endArray == -1 {
+		end = endObject
+	} else {
+		end = max(endObject, endArray)
 	}
+
 	return jsonStr[:end+1]
 }
 
-func trimJSON(jsonStr string) string {
+// Extracts the JSON by trimming prefixes and postfixes
+func extractJSON(jsonStr string) string {
 	trimmedPrefix := trimPrefix(jsonStr)
 	trimmedJSON := trimPostfix(trimmedPrefix)
 	return trimmedJSON

--- a/pkg/instructor/schema.go
+++ b/pkg/instructor/schema.go
@@ -7,7 +7,7 @@ import (
 	"github.com/invopop/jsonschema"
 )
 
-type Schema[T any] struct {
+type Schema struct {
 	*jsonschema.Schema
 	String string
 
@@ -25,22 +25,18 @@ type FunctionDefinition struct {
 	Parameters  *jsonschema.Schema `json:"parameters"`
 }
 
-func NewSchema[T any]() (*Schema[T], error) {
+func NewSchema(t reflect.Type) (*Schema, error) {
 
-	t := new(T)
-
-	tType := reflect.TypeOf(t)
-
-	schema := jsonschema.ReflectFromType(tType)
+	schema := jsonschema.ReflectFromType(t)
 
 	str, err := json.MarshalIndent(schema, "", "  ")
 	if err != nil {
 		return nil, err
 	}
 
-	funcs := ToFunctionSchema(tType, schema)
+	funcs := ToFunctionSchema(t, schema)
 
-	s := &Schema[T]{
+	s := &Schema{
 		Schema: schema,
 		String: string(str),
 

--- a/pkg/instructor/utils.go
+++ b/pkg/instructor/utils.go
@@ -44,3 +44,17 @@ func urlToBase64(url string) (string, error) {
 
 	return base64.StdEncoding.EncodeToString(data), nil
 }
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
To make methods generic, the struct must be generic to return the generic type. This is not good because then you need to create a new instructor client for every type you want to use.

Now, I wrappe the OpenAI Messages API to include a new argument (`response`) where the return value will be loaded into, similar to `json.Unmarshal(json bytes, struct pointer)`.

This is approach is much cleaner and also allows the implementation clients not to have to worry about the generic and response value from the instructor client, but just be passed the schema str and mode.
