### PR TITLE
Count all usage from failures to unmarshal and validate json

### DIFF
--- a/pkg/instructor/chat.go
+++ b/pkg/instructor/chat.go
@@ -4,10 +4,19 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	cohere "github.com/cohere-ai/cohere-go/v2"
+	"github.com/liushuangls/go-anthropic/v2"
+	"github.com/sashabaranov/go-openai"
 	"reflect"
 
 	"github.com/go-playground/validator/v10"
 )
+
+type UsageSum struct {
+	InputTokens  int
+	OutputTokens int
+	TotalTokens  int
+}
 
 func chatHandler(i Instructor, ctx context.Context, request interface{}, response any) (interface{}, error) {
 
@@ -20,12 +29,15 @@ func chatHandler(i Instructor, ctx context.Context, request interface{}, respons
 		return nil, err
 	}
 
+	// keep a running total of usage
+	usage := &UsageSum{}
+
 	for attempt := 0; attempt < i.MaxRetries(); attempt++ {
 
 		text, resp, err := i.chat(ctx, request, schema)
 		if err != nil {
 			// no retry on non-marshalling/validation errors
-			return nil, err
+			return nilChatRespWithUsage(resp), err
 		}
 
 		text = extractJSON(&text)
@@ -37,6 +49,8 @@ func chatHandler(i Instructor, ctx context.Context, request interface{}, respons
 			//
 			// Currently, its just recalling with no new information
 			// or attempt to fix the error with the last generated JSON
+
+			countUsageFromResp(resp, usage)
 			continue
 		}
 
@@ -48,12 +62,66 @@ func chatHandler(i Instructor, ctx context.Context, request interface{}, respons
 			if err != nil {
 				// TODO:
 				// add more sophisticated retry logic (send back validator error and parse error for model to fix).
+
+				countUsageFromResp(resp, usage)
 				continue
 			}
 		}
 
-		return resp, nil
+		return addUsageSumToResp(resp, usage), nil
 	}
 
-	return nil, errors.New("hit max retry attempts")
+	return i.EmptyResponseWithUsage(usage), errors.New("hit max retry attempts")
+}
+
+func nilChatRespWithUsage(response interface{}) interface{} {
+	switch resp := response.(type) {
+	case nil:
+		return nil
+	case *openai.ChatCompletionResponse:
+		return &openai.ChatCompletionResponse{
+			Usage: resp.Usage,
+		}
+	case *anthropic.MessagesResponse:
+		return &anthropic.MessagesResponse{
+			Usage: resp.Usage,
+		}
+	case *cohere.NonStreamedChatResponse:
+		return &cohere.NonStreamedChatResponse{
+			Meta: resp.Meta,
+		}
+	default:
+		return nil
+	}
+}
+
+func addUsageSumToResp(response interface{}, usage *UsageSum) interface{} {
+	switch resp := response.(type) {
+	case *openai.ChatCompletionResponse:
+		resp.Usage.PromptTokens += usage.InputTokens
+		resp.Usage.CompletionTokens += usage.OutputTokens
+		resp.Usage.TotalTokens += usage.TotalTokens
+	case *anthropic.MessagesResponse:
+		resp.Usage.InputTokens += usage.InputTokens
+		resp.Usage.OutputTokens += usage.OutputTokens
+	case *cohere.NonStreamedChatResponse:
+		*resp.Meta.Tokens.InputTokens += float64(usage.InputTokens)
+		*resp.Meta.Tokens.OutputTokens += float64(usage.OutputTokens)
+	}
+	return response
+}
+
+func countUsageFromResp(response interface{}, usage *UsageSum) {
+	switch resp := response.(type) {
+	case *openai.ChatCompletionResponse:
+		usage.InputTokens += resp.Usage.PromptTokens
+		usage.OutputTokens += resp.Usage.CompletionTokens
+		usage.TotalTokens += resp.Usage.TotalTokens
+	case *anthropic.MessagesResponse:
+		usage.InputTokens += resp.Usage.InputTokens
+		usage.OutputTokens += resp.Usage.OutputTokens
+	case *cohere.NonStreamedChatResponse:
+		usage.InputTokens += int(*resp.Meta.Tokens.InputTokens)
+		usage.OutputTokens += int(*resp.Meta.Tokens.OutputTokens)
+	}
 }

--- a/pkg/instructor/cohere_chat.go
+++ b/pkg/instructor/cohere_chat.go
@@ -17,6 +17,7 @@ func (i *InstructorCohere) Chat(
 
 	resp, err := chatHandler(i, ctx, request, response)
 	if err != nil {
+		// TODO: propagate usage for failed calls when tool calls are implemented
 		return nil, err
 	}
 
@@ -78,6 +79,11 @@ func (i *InstructorCohere) addOrConcatJSONSystemPrompt(request *cohere.ChatReque
 	} else {
 		request.Preamble = toPtr(*request.Preamble + "\n" + schemaPrompt)
 	}
+}
+
+func (i *InstructorCohere) EmptyResponseWithUsage(usage *UsageSum) interface{} {
+	// TODO: implement
+	return nil
 }
 
 func createCohereTools(schema *Schema) *cohere.Tool {

--- a/pkg/instructor/instructor.go
+++ b/pkg/instructor/instructor.go
@@ -13,6 +13,7 @@ type Instructor interface {
 	Mode() Mode
 	MaxRetries() int
 	Validate() bool
+	EmptyResponseWithUsage(usage *UsageSum) interface{}
 
 	// Chat / Messages
 


### PR DESCRIPTION
* Added tallying of usage for retries
* Lots of nil response returns, I replaced these (except for Cohere, stubbed that as a TODO) with empty responses containing only usage data