### PR TITLE
bug: fix openai and google tool results

### DIFF
--- a/examples/agent/main.go
+++ b/examples/agent/main.go
@@ -53,12 +53,14 @@ func NewAgent(client *instructor.InstructorOpenAI) *Agent {
 	return &Agent{
 		client: client,
 		conversation: core.NewConversation(`You are a helpful agent that can use tools to answer questions.
+
 Available tools:
 - search: Search for information
 - lookup: Look up detailed information about a specific keyword
 - finish: Return the final answer
 
-Use the tools step by step to gather information before finishing with your answer.`),
+IMPORTANT: You MUST always respond by calling one of these tools. Never respond with plain text.
+Use the tools step by step to gather information, then call "finish" with your final answer.`),
 	}
 }
 
@@ -71,15 +73,16 @@ func (a *Agent) Run(ctx context.Context, goal string) (string, error) {
 		fmt.Printf("\n--- Turn %d ---\n", turn+1)
 
 		// Let the LLM choose a tool
-		action, resp, err := a.client.CreateChatCompletionUnion(
+		actions, resp, err := a.client.CreateChatCompletionUnion(
 			ctx,
 			openai.ChatCompletionRequest{
 				Model:    openai.GPT5Mini,
 				Messages: instructor_openai.ConversationToMessages(a.conversation),
 			},
 			instructor.UnionOptions{
-				Discriminator: "type",
-				Variants:      []any{SearchTool{}, LookupTool{}, FinishTool{}},
+				Discriminator:   "type",
+				Variants:        []any{SearchTool{}, LookupTool{}, FinishTool{}},
+				RequireToolCall: true, // Prevent plain text responses - model must always call a tool
 			},
 		)
 		if err != nil {
@@ -92,6 +95,13 @@ func (a *Agent) Run(ctx context.Context, goal string) (string, error) {
 			resp.Usage.PromptTokens,
 			resp.Usage.CompletionTokens,
 		)
+
+		// For this simple agent, we expect only one action per turn
+		if len(actions) == 0 {
+			return "", fmt.Errorf("no action returned from LLM")
+		}
+
+		action := actions[0]
 
 		// Execute the tool based on its type
 		var result string

--- a/examples/anthropic_agent/main.go
+++ b/examples/anthropic_agent/main.go
@@ -42,11 +42,13 @@ func NewAgent(client *instructor.InstructorAnthropic) *Agent {
 	return &Agent{
 		client: client,
 		conversation: core.NewConversation(`You are a helpful agent that can use tools to answer questions.
+
 Available tools:
 - search: Search for information
 - finish: Return the final answer
 
-Use tools step by step to gather information before finishing with your answer.`),
+IMPORTANT: You MUST always respond by calling one of these tools. Never respond with plain text.
+Use tools step by step to gather information, then call "finish" with your final answer.`),
 	}
 }
 
@@ -62,7 +64,7 @@ func (a *Agent) Run(ctx context.Context, goal string) (string, error) {
 		system, messages := anthropic_provider.ConversationToMessages(a.conversation)
 
 		// Let the LLM choose a tool
-		action, resp, err := a.client.CreateMessagesUnion(
+		actions, resp, err := a.client.CreateMessagesUnion(
 			ctx,
 			anthropic.MessagesRequest{
 				Model:     anthropic.ModelClaude3Haiku20240307,
@@ -71,8 +73,9 @@ func (a *Agent) Run(ctx context.Context, goal string) (string, error) {
 				MaxTokens: 1024,
 			},
 			instructor.UnionOptions{
-				Discriminator: "type",
-				Variants:      []any{SearchTool{}, FinishTool{}},
+				Discriminator:   "type",
+				Variants:        []any{SearchTool{}, FinishTool{}},
+				RequireToolCall: true, // Prevent plain text responses - model must always call a tool
 			},
 		)
 		if err != nil {
@@ -88,6 +91,13 @@ func (a *Agent) Run(ctx context.Context, goal string) (string, error) {
 			resp.Usage.InputTokens,
 			resp.Usage.OutputTokens,
 		)
+
+		// For this simple agent, we expect only one action per turn
+		if len(actions) == 0 {
+			return "", fmt.Errorf("no action returned from LLM")
+		}
+
+		action := actions[0]
 
 		// Execute the tool based on its type
 		var result string

--- a/pkg/instructor/core/union.go
+++ b/pkg/instructor/core/union.go
@@ -12,8 +12,9 @@ import (
 
 // UnionOptions configures union type extraction
 type UnionOptions struct {
-	Discriminator string // Field name used for discrimination (e.g. "type")
-	Variants      []any  // Concrete instances of each variant type
+	Discriminator   string // Field name used for discrimination (e.g. "type")
+	Variants        []any  // Concrete instances of each variant type
+	RequireToolCall bool   // If true, force the model to always call a tool (prevents plain text responses)
 }
 
 // UnionSchema represents a discriminated union

--- a/pkg/instructor/providers/anthropic/chat.go
+++ b/pkg/instructor/providers/anthropic/chat.go
@@ -33,6 +33,13 @@ func (i *InstructorAnthropic) CreateMessagesUnion(
 	opts core.UnionOptions,
 ) (result []any, response anthropic.MessagesResponse, err error) {
 
+	// Apply RequireToolCall option if set
+	if opts.RequireToolCall {
+		request.ToolChoice = &anthropic.ToolChoice{
+			Type: "any",
+		}
+	}
+
 	result, resp, err := core.ChatHandlerUnion(i, ctx, request, opts)
 	if err != nil {
 		if resp == nil {

--- a/pkg/instructor/providers/google/conversation.go
+++ b/pkg/instructor/providers/google/conversation.go
@@ -1,6 +1,8 @@
 package google
 
 import (
+	"encoding/json"
+
 	"github.com/567-labs/instructor-go/pkg/instructor/core"
 	"google.golang.org/genai"
 )
@@ -45,16 +47,107 @@ func ToGoogleContents(messages []core.Message) []*genai.Content {
 		case core.RoleSystem:
 			// Google doesn't have a dedicated system role, treat as user message
 			role = "user"
+		case core.RoleTool:
+			// Tool responses are sent as user messages
+			role = "user"
 		default:
 			continue
 		}
 
-		result = append(result, &genai.Content{
-			Role: role,
-			Parts: []*genai.Part{
-				{Text: msg.Content},
-			},
-		})
+		// If ContentBlocks is set, use structured content (takes precedence)
+		if len(msg.ContentBlocks) > 0 {
+			parts := make([]*genai.Part, 0)
+
+			for _, block := range msg.ContentBlocks {
+				switch block.Type {
+				case core.ContentBlockTypeText:
+					if block.Text != "" {
+						parts = append(parts, &genai.Part{
+							Text: block.Text,
+						})
+					}
+
+				case core.ContentBlockTypeToolUse:
+					if block.ToolUse != nil {
+						// Convert input to map[string]any if needed
+						var args map[string]any
+						switch v := block.ToolUse.Input.(type) {
+						case map[string]any:
+							args = v
+						case []byte:
+							// Try to unmarshal JSON
+							var m map[string]any
+							if err := json.Unmarshal(v, &m); err == nil {
+								args = m
+							} else {
+								// If unmarshal fails, wrap in a generic field
+								args = map[string]any{"data": string(v)}
+							}
+						case string:
+							// Try to unmarshal JSON string
+							var m map[string]any
+							if err := json.Unmarshal([]byte(v), &m); err == nil {
+								args = m
+							} else {
+								args = map[string]any{"data": v}
+							}
+						default:
+							// For other types, try to convert via JSON round-trip
+							data, err := json.Marshal(v)
+							if err == nil {
+								var m map[string]any
+								if err := json.Unmarshal(data, &m); err == nil {
+									args = m
+								}
+							}
+						}
+
+						if args != nil {
+							parts = append(parts, genai.NewPartFromFunctionCall(
+								block.ToolUse.Name,
+								args,
+							))
+						}
+					}
+
+				case core.ContentBlockTypeToolResult:
+					if block.ToolResult != nil {
+						// Create function response
+						// For Google, we need to extract the function name from the tool use ID
+						// Since Google uses the function name as the ID in our implementation
+						response := map[string]any{
+							"result": block.ToolResult.Content,
+						}
+
+						if block.ToolResult.IsError {
+							response = map[string]any{
+								"error": block.ToolResult.Content,
+							}
+						}
+
+						parts = append(parts, genai.NewPartFromFunctionResponse(
+							block.ToolResult.ToolUseID, // This is the function name in Google's case
+							response,
+						))
+					}
+				}
+			}
+
+			if len(parts) > 0 {
+				result = append(result, &genai.Content{
+					Role:  role,
+					Parts: parts,
+				})
+			}
+		} else {
+			// Fallback to legacy fields for backward compatibility
+			result = append(result, &genai.Content{
+				Role: role,
+				Parts: []*genai.Part{
+					{Text: msg.Content},
+				},
+			})
+		}
 	}
 
 	return result

--- a/pkg/instructor/providers/google/conversation_response_test.go
+++ b/pkg/instructor/providers/google/conversation_response_test.go
@@ -358,6 +358,125 @@ func TestGoogleConversationRoundTrip(t *testing.T) {
 		if len(contents) != 2 {
 			t.Errorf("Expected 2 contents, got %d", len(contents))
 		}
+
+		// Verify assistant message with function call
+		if contents[1].Role != "model" {
+			t.Errorf("Content 1 role = %q, want 'model'", contents[1].Role)
+		}
+		if len(contents[1].Parts) != 2 { // text + function call
+			t.Fatalf("Expected 2 parts, got %d", len(contents[1].Parts))
+		}
+		if contents[1].Parts[0].Text != "Let me search" {
+			t.Errorf("Part 0 text = %q, want 'Let me search'", contents[1].Parts[0].Text)
+		}
+		if contents[1].Parts[1].FunctionCall == nil {
+			t.Fatal("Part 1 should have FunctionCall")
+		}
+		if contents[1].Parts[1].FunctionCall.Name != "search" {
+			t.Errorf("Function name = %q, want 'search'", contents[1].Parts[1].FunctionCall.Name)
+		}
+	})
+
+	t.Run("conversation with tool result conversion", func(t *testing.T) {
+		conv := core.NewConversation()
+		conv.AddUserMessage("Test")
+		conv.AddAssistantMessageWithToolUse("",
+			core.ToolUseBlock{
+				ID:    "search",
+				Name:  "search",
+				Input: map[string]any{"query": "Go"},
+			},
+		)
+		conv.AddToolResultMessage("search", "Results here", false)
+
+		contents := ConversationToContents(conv)
+
+		// Verify we have 3 contents: user, model (with function call), user (with function response)
+		if len(contents) != 3 {
+			t.Fatalf("Expected 3 contents, got %d", len(contents))
+		}
+
+		// Verify function response content
+		responseContent := contents[2]
+		if responseContent.Role != "user" {
+			t.Errorf("Function response role = %q, want 'user'", responseContent.Role)
+		}
+		if len(responseContent.Parts) != 1 {
+			t.Fatalf("Expected 1 part in response, got %d", len(responseContent.Parts))
+		}
+		if responseContent.Parts[0].FunctionResponse == nil {
+			t.Fatal("Part should have FunctionResponse")
+		}
+		if responseContent.Parts[0].FunctionResponse.Name != "search" {
+			t.Errorf("Function response name = %q, want 'search'", responseContent.Parts[0].FunctionResponse.Name)
+		}
+		if responseContent.Parts[0].FunctionResponse.Response["result"] != "Results here" {
+			t.Errorf("Function response result = %v, want 'Results here'", responseContent.Parts[0].FunctionResponse.Response["result"])
+		}
+	})
+
+	t.Run("tool result with error flag", func(t *testing.T) {
+		conv := core.NewConversation()
+		conv.AddUserMessage("Test")
+		conv.AddAssistantMessageWithToolUse("",
+			core.ToolUseBlock{
+				ID:    "calculate",
+				Name:  "calculate",
+				Input: map[string]any{"op": "divide", "a": 10, "b": 0},
+			},
+		)
+		conv.AddToolResultMessage("calculate", "Division by zero error", true)
+
+		contents := ConversationToContents(conv)
+
+		// Find the function response
+		var funcResp *genai.FunctionResponse
+		for _, content := range contents {
+			for _, part := range content.Parts {
+				if part.FunctionResponse != nil {
+					funcResp = part.FunctionResponse
+					break
+				}
+			}
+		}
+
+		if funcResp == nil {
+			t.Fatal("No function response found")
+		}
+
+		// For errors, response should have "error" key
+		if funcResp.Response["error"] != "Division by zero error" {
+			t.Errorf("Function response error = %v, want 'Division by zero error'", funcResp.Response["error"])
+		}
+	})
+
+	t.Run("multiple tool results in sequence", func(t *testing.T) {
+		conv := core.NewConversation()
+		conv.AddUserMessage("Test")
+		conv.AddAssistantMessageWithToolUse("",
+			core.ToolUseBlock{ID: "search", Name: "search", Input: map[string]any{"q": "test"}},
+			core.ToolUseBlock{ID: "lookup", Name: "lookup", Input: map[string]any{"key": "value"}},
+		)
+		conv.AddToolResultMessages(
+			core.ToolResultBlock{ToolUseID: "search", Content: "Result 1", IsError: false},
+			core.ToolResultBlock{ToolUseID: "lookup", Content: "Result 2", IsError: false},
+		)
+
+		contents := ConversationToContents(conv)
+
+		// Count function responses
+		funcResponseCount := 0
+		for _, content := range contents {
+			for _, part := range content.Parts {
+				if part.FunctionResponse != nil {
+					funcResponseCount++
+				}
+			}
+		}
+
+		if funcResponseCount != 2 {
+			t.Errorf("Expected 2 function responses, got %d", funcResponseCount)
+		}
 	})
 }
 

--- a/pkg/instructor/providers/openai/chat.go
+++ b/pkg/instructor/providers/openai/chat.go
@@ -46,6 +46,11 @@ func (i *InstructorOpenAI) CreateChatCompletionUnion(
 	opts core.UnionOptions,
 ) (result []any, response openai.ChatCompletionResponse, err error) {
 
+	// Apply RequireToolCall option if set
+	if opts.RequireToolCall {
+		request.ToolChoice = "required"
+	}
+
 	result, resp, err := core.ChatHandlerUnion(i, ctx, request, opts)
 	if err != nil {
 		if resp == nil {

--- a/pkg/instructor/providers/openai/conversation.go
+++ b/pkg/instructor/providers/openai/conversation.go
@@ -45,10 +45,79 @@ func (h *ResponseHandler) AddResponseWithToolResult(conv *core.Conversation, res
 
 // ToOpenAIMessages converts unified conversation messages to OpenAI format
 func ToOpenAIMessages(messages []core.Message) []openai.ChatCompletionMessage {
-	result := make([]openai.ChatCompletionMessage, len(messages))
-	for i, msg := range messages {
-		// If the message has images, use MultiContent
-		if len(msg.Images) > 0 {
+	result := make([]openai.ChatCompletionMessage, 0, len(messages))
+
+	for _, msg := range messages {
+		// If ContentBlocks is set, use structured content (takes precedence)
+		if len(msg.ContentBlocks) > 0 {
+			// Check if this is a tool result message
+			hasToolResult := false
+			for _, block := range msg.ContentBlocks {
+				if block.Type == core.ContentBlockTypeToolResult {
+					hasToolResult = true
+					break
+				}
+			}
+
+			if hasToolResult {
+				// Handle tool result messages - each tool result becomes a separate message
+				for _, block := range msg.ContentBlocks {
+					if block.Type == core.ContentBlockTypeToolResult && block.ToolResult != nil {
+						result = append(result, openai.ChatCompletionMessage{
+							Role:       string(core.RoleTool),
+							Content:    block.ToolResult.Content,
+							ToolCallID: block.ToolResult.ToolUseID,
+						})
+					}
+				}
+			} else {
+				// Handle assistant messages with tool calls
+				openaiMsg := openai.ChatCompletionMessage{
+					Role: string(msg.Role),
+				}
+
+				textContent := ""
+				toolCalls := make([]openai.ToolCall, 0)
+
+				for _, block := range msg.ContentBlocks {
+					switch block.Type {
+					case core.ContentBlockTypeText:
+						textContent += block.Text
+					case core.ContentBlockTypeToolUse:
+						if block.ToolUse != nil {
+							// Convert input to string
+							var argsStr string
+							switch v := block.ToolUse.Input.(type) {
+							case string:
+								argsStr = v
+							case []byte:
+								argsStr = string(v)
+							default:
+								// Already in the right format (json.RawMessage or similar)
+								argsStr = string(v.([]byte))
+							}
+
+							toolCalls = append(toolCalls, openai.ToolCall{
+								ID:   block.ToolUse.ID,
+								Type: openai.ToolTypeFunction,
+								Function: openai.FunctionCall{
+									Name:      block.ToolUse.Name,
+									Arguments: argsStr,
+								},
+							})
+						}
+					}
+				}
+
+				openaiMsg.Content = textContent
+				if len(toolCalls) > 0 {
+					openaiMsg.ToolCalls = toolCalls
+				}
+
+				result = append(result, openaiMsg)
+			}
+		} else if len(msg.Images) > 0 {
+			// If the message has images, use MultiContent
 			parts := make([]openai.ChatMessagePart, 0, len(msg.Images)+1)
 
 			// Add text part if content is not empty
@@ -83,20 +152,20 @@ func ToOpenAIMessages(messages []core.Message) []openai.ChatCompletionMessage {
 				parts = append(parts, imagePart)
 			}
 
-			result[i] = openai.ChatCompletionMessage{
+			result = append(result, openai.ChatCompletionMessage{
 				Role:         string(msg.Role),
 				MultiContent: parts,
 				Name:         msg.Name,
 				ToolCallID:   msg.ToolCallID,
-			}
+			})
 		} else {
 			// Simple text message
-			result[i] = openai.ChatCompletionMessage{
+			result = append(result, openai.ChatCompletionMessage{
 				Role:       string(msg.Role),
 				Content:    msg.Content,
 				Name:       msg.Name,
 				ToolCallID: msg.ToolCallID,
-			}
+			})
 		}
 	}
 	return result

--- a/pkg/instructor/providers/openai/conversation_response_test.go
+++ b/pkg/instructor/providers/openai/conversation_response_test.go
@@ -328,6 +328,117 @@ func TestOpenAIConversationRoundTrip(t *testing.T) {
 		if len(messages) != 3 {
 			t.Errorf("Expected 3 messages, got %d", len(messages))
 		}
+
+		// Verify assistant message with tool call
+		if messages[1].Role != "assistant" {
+			t.Errorf("Message 1 role = %q, want 'assistant'", messages[1].Role)
+		}
+		if len(messages[1].ToolCalls) != 1 {
+			t.Fatalf("Expected 1 tool call, got %d", len(messages[1].ToolCalls))
+		}
+		if messages[1].ToolCalls[0].ID != "call_123" {
+			t.Errorf("Tool call ID = %q, want 'call_123'", messages[1].ToolCalls[0].ID)
+		}
+		if messages[1].ToolCalls[0].Function.Name != "search" {
+			t.Errorf("Tool name = %q, want 'search'", messages[1].ToolCalls[0].Function.Name)
+		}
+
+		// Verify tool result message
+		if messages[2].Role != "tool" {
+			t.Errorf("Message 2 role = %q, want 'tool'", messages[2].Role)
+		}
+		if messages[2].ToolCallID != "call_123" {
+			t.Errorf("Tool call ID = %q, want 'call_123'", messages[2].ToolCallID)
+		}
+		if messages[2].Content != "Results here" {
+			t.Errorf("Tool result content = %q, want 'Results here'", messages[2].Content)
+		}
+	})
+
+	t.Run("tool result conversion with proper role and ID", func(t *testing.T) {
+		conv := core.NewConversation()
+		conv.AddUserMessage("Test")
+		conv.AddAssistantMessageWithToolUse("",
+			core.ToolUseBlock{
+				ID:    "call_abc123",
+				Name:  "test_tool",
+				Input: []byte(`{}`),
+			},
+		)
+		conv.AddToolResultMessage("call_abc123", "Tool output", false)
+
+		messages := ConversationToMessages(conv)
+
+		// Find the tool result message
+		var toolResultMsg *openai.ChatCompletionMessage
+		for i, msg := range messages {
+			if msg.Role == "tool" {
+				toolResultMsg = &messages[i]
+				break
+			}
+		}
+
+		if toolResultMsg == nil {
+			t.Fatal("No tool result message found")
+		}
+
+		if toolResultMsg.Role != "tool" {
+			t.Errorf("Role = %q, want 'tool'", toolResultMsg.Role)
+		}
+		if toolResultMsg.ToolCallID != "call_abc123" {
+			t.Errorf("ToolCallID = %q, want 'call_abc123'", toolResultMsg.ToolCallID)
+		}
+		if toolResultMsg.Content != "Tool output" {
+			t.Errorf("Content = %q, want 'Tool output'", toolResultMsg.Content)
+		}
+	})
+
+	t.Run("multiple tool results in one message", func(t *testing.T) {
+		conv := core.NewConversation()
+		conv.AddUserMessage("Test")
+		conv.AddAssistantMessageWithToolUse("",
+			core.ToolUseBlock{ID: "call_1", Name: "tool1", Input: []byte(`{}`)},
+			core.ToolUseBlock{ID: "call_2", Name: "tool2", Input: []byte(`{}`)},
+		)
+		conv.AddToolResultMessages(
+			core.ToolResultBlock{ToolUseID: "call_1", Content: "Result 1", IsError: false},
+			core.ToolResultBlock{ToolUseID: "call_2", Content: "Result 2", IsError: false},
+		)
+
+		messages := ConversationToMessages(conv)
+
+		// Count tool result messages
+		toolResultCount := 0
+		for _, msg := range messages {
+			if msg.Role == "tool" {
+				toolResultCount++
+			}
+		}
+
+		if toolResultCount != 2 {
+			t.Errorf("Expected 2 tool result messages, got %d", toolResultCount)
+		}
+
+		// Verify both results are present with correct IDs
+		foundCall1 := false
+		foundCall2 := false
+		for _, msg := range messages {
+			if msg.Role == "tool" {
+				if msg.ToolCallID == "call_1" && msg.Content == "Result 1" {
+					foundCall1 = true
+				}
+				if msg.ToolCallID == "call_2" && msg.Content == "Result 2" {
+					foundCall2 = true
+				}
+			}
+		}
+
+		if !foundCall1 {
+			t.Error("Tool result for call_1 not found")
+		}
+		if !foundCall2 {
+			t.Error("Tool result for call_2 not found")
+		}
 	})
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enforce tool usage in AI responses by setting `RequireToolCall` in `UnionOptions`, updating logic for OpenAI, Anthropic, and Google, and enhancing tests for tool result handling.
> 
>   - **Behavior**:
>     - Enforce tool usage by setting `RequireToolCall` in `UnionOptions` in `main.go` for both OpenAI and Anthropic agents.
>     - Update `CreateChatCompletionUnion` in `chat.go` for OpenAI and Anthropic to respect `RequireToolCall`.
>     - Modify `ToGoogleContents` in `conversation.go` to handle structured content and tool results for Google.
>   - **Functionality**:
>     - Add logic to handle multiple tool results and ensure correct tool call IDs in `conversation_response_test.go` for both Google and OpenAI.
>     - Implement structured content handling in `ToOpenAIMessages` and `ToGoogleContents`.
>   - **Testing**:
>     - Add tests in `conversation_response_test.go` for handling multiple tool results and ensuring backward compatibility.
>     - Verify tool result conversion and function call handling in `TestGoogleConversationRoundTrip` and `TestOpenAIConversationRoundTrip`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor-go&utm_source=github&utm_medium=referral)<sup> for a22eb3fbd527c4f3321ce252884a76541d3d9859. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->