### PR TITLE
Add error detection for empty response in JSON mode

### DIFF
--- a/pkg/instructor/providers/openai/chat.go
+++ b/pkg/instructor/providers/openai/chat.go
@@ -213,6 +213,12 @@ func (i *InstructorOpenAI) chatJSON(ctx context.Context, request *openai.ChatCom
 
 	text := resp.Choices[0].Message.Content
 
+	// Check for empty response - this can happen when the API doesn't support
+	// the json_object response format (e.g., some OpenAI-compatible APIs)
+	if text == "" {
+		return "", nilOpenaiRespWithUsage(&resp), errors.New("received empty response from model - the model may not support the 'json_object' response format. Try using ModeJSONSchema or ModeToolCall instead")
+	}
+
 	if strict {
 		resMap := make(map[string]any)
 		_ = json.Unmarshal([]byte(text), &resMap)


### PR DESCRIPTION
Hello, thank you for the good work. This was really annoying me so I went ahead and added a small fix for it.

When using ModeJSON with OpenAI-compatible APIs (like DeepInfra/GLM-5), the json_object response format is not supported and returns empty content. This fix detects empty responses and provides a helpful error message suggesting alternative modes (ModeJSONSchema or ModeToolCall).